### PR TITLE
Update go.mod (mod name mismatch)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/TopiSenpai/paginator
+module github.com/TopiSenpai/dgo-paginator
 
 go 1.17
 


### PR DESCRIPTION
Fix module name mismatch

The module said "I am github.com/TopiSenpai/paginator", but it lives at "github.com/TopiSenpai/dgo-paginator"